### PR TITLE
Fix deriveChatChannel text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.smartchatinputcolor'
-version = '1.4.0'
+version = '1.4.1'
 sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.smartchatinputcolor'
-version = '1.4.1'
+version = '1.4.2'
 
 tasks.withType(JavaCompile) {
 	options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ dependencies {
 
 group = 'com.smartchatinputcolor'
 version = '1.4.1'
-sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {
 	options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ def runeLiteVersion = 'latest.release'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.13.1'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,5 @@
 displayName=Smart Chat Input Color
 author=MarbleTurtle
-support=https://github.com/MarbleTurtle/Color-Coordinator
 description=Recolors the chat input field according to which channel the message will be sent to.
 tags=chat,color,input
 plugins=com.smartchatinputcolor.SmartChatInputColorPlugin

--- a/src/main/java/com/smartchatinputcolor/ChatChannel.java
+++ b/src/main/java/com/smartchatinputcolor/ChatChannel.java
@@ -29,7 +29,7 @@ enum ChatChannel {
 			VarPlayer.SETTINGS_OPAQUE_CHAT_CLAN,
 			0x7F0000,
 			0x7F0000,
-			Pattern.compile("^/(@?c|/).*")),
+			Pattern.compile("^/(@c|c |/).*")),
 	GUEST(
 			"ClanGuestMessage",
 			VarPlayer.SETTINGS_TRANSPARENT_CHAT_GUEST_CLAN,

--- a/src/main/java/com/smartchatinputcolor/ChatChannel.java
+++ b/src/main/java/com/smartchatinputcolor/ChatChannel.java
@@ -16,7 +16,7 @@ enum ChatChannel {
 			VarPlayer.SETTINGS_OPAQUE_CHAT_PUBLIC,
 			0x9090FF,
 			0x0000FF,
-			Pattern.compile("^/@?p.*")),
+			Pattern.compile("^/(@p|p ).*")),
 	FRIEND("ClanChatMessage",
 			VarPlayer.SETTINGS_TRANSPARENT_CHAT_FRIEND,
 			VarPlayer.SETTINGS_OPAQUE_CHAT_FRIEND,

--- a/src/main/java/com/smartchatinputcolor/ChatChannel.java
+++ b/src/main/java/com/smartchatinputcolor/ChatChannel.java
@@ -36,7 +36,7 @@ enum ChatChannel {
 			VarPlayer.SETTINGS_OPAQUE_CHAT_GUEST_CLAN,
 			0x7F0000,
 			0x7F0000,
-			Pattern.compile("^/(@?gc|//).*")),
+			Pattern.compile("^/(@gc|gc |//).*")),
 	GIM(
 			null,
 			VarPlayer.SETTINGS_TRANSPARENT_CHAT_IRON_GROUP_CHAT,

--- a/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
+++ b/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
@@ -10,9 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.annotations.Varp;
 import net.runelite.api.events.*;
-import net.runelite.api.vars.AccountType;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -69,7 +67,7 @@ public class SmartChatInputColorPlugin extends Plugin {
 	 * the channel that the message will be sent to
 	 */
 	private void recolorChatTypedText() {
-		Widget inputWidget = client.getWidget(WidgetInfo.CHATBOX_INPUT);
+		Widget inputWidget = client.getWidget(ComponentID.CHATBOX_INPUT);
 		if (inputWidget == null) {
 			return;
 		}
@@ -214,8 +212,11 @@ public class SmartChatInputColorPlugin extends Plugin {
 	 * @return Chat channel that the message will go to
 	 */
 	private ChatChannel getGIMChatChannel(String text) {
-		if (client.getAccountType() == AccountType.GROUP_IRONMAN) {
-			return ChatChannel.GIM;
+		switch (client.getVarbitValue(Varbits.ACCOUNT_TYPE)) {
+			case 4: // GIM
+			case 5: // HCGIM
+			case 6: // UGIM
+				return ChatChannel.GIM;
 		}
 
 		if (text.startsWith("/g")) {

--- a/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
+++ b/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
@@ -117,12 +117,14 @@ public class SmartChatInputColorPlugin extends Plugin {
 		if (ChatChannel.CLAN.matchesRegex(text)) {
 			return ChatChannel.CLAN;
 		}
-		if (ChatChannel.FRIEND.matchesRegex(text)) {
-			return getFriendsChatChannel();
-		}
 		if (ChatChannel.PUBLIC.matchesRegex(text)) {
 			return ChatChannel.PUBLIC;
 		}
+		// Check FC last. Otherwise, it will match "/" too soon.
+		if (ChatChannel.FRIEND.matchesRegex(text)) {
+			return getFriendsChatChannel();
+		}
+
 
 		// If not a prefix, check if in a certain chat mode
 		if (name.contains("(")) {

--- a/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
+++ b/src/main/java/com/smartchatinputcolor/SmartChatInputColorPlugin.java
@@ -3,6 +3,7 @@ package com.smartchatinputcolor;
 import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.*;
 import javax.inject.Inject;
 
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
Removes deprecated APIs
Implements changes made to the example-plugin
Fixes messages like ``/cool`` being the wrong color (fixes #12)
Fixes messages like ``/gcstar`` being the wrong color
Fixes messages like ``/p hello world`` being the wrong color
Please refer to the commmit messages for more details. Feel free to DM me on Discord ofc.